### PR TITLE
Sliders updated

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -111,6 +111,7 @@ if sys.argv[1] == 'test':
             app_sequence=['sliders'],
             trial_delay=PUZZLE_DELAY,
             retry_delay=RETRY_DELAY,
-            num_sliders=3
+            num_sliders=3,
+            attempts_per_slider=3
         )
     )

--- a/settings.py
+++ b/settings.py
@@ -44,7 +44,7 @@ SESSION_CONFIG_DEFAULTS = dict(
     real_world_currency_per_point=1.00, participation_fee=0.00, doc=""
 )
 
-PARTICIPANT_FIELDS = []
+PARTICIPANT_FIELDS = ['is_dropout']
 SESSION_FIELDS = ['task_params']
 
 # ISO-639 code
@@ -104,3 +104,13 @@ if sys.argv[1] == 'test':
                 ),
             ]
         )
+    SESSION_CONFIGS.append(
+        dict(
+            name=f"sliders",
+            num_demo_participants=1,
+            app_sequence=['sliders'],
+            trial_delay=PUZZLE_DELAY,
+            retry_delay=RETRY_DELAY,
+            num_sliders=3
+        )
+    )

--- a/sliders/Game.html
+++ b/sliders/Game.html
@@ -8,8 +8,6 @@ Sliders task
 
 {{ block content }}
 <div class="d-flex flex-column align-items-center">
-<!--    <progress id="progress-bar" max="{{ params.num_iterations}}" value="0"></progress>-->
-
     <canvas id="canvas" class="m-2"></canvas>
 
     {{ if DEBUG }}

--- a/sliders/Game.html
+++ b/sliders/Game.html
@@ -8,6 +8,8 @@ Sliders task
 
 {{ block content }}
 <div class="d-flex flex-column align-items-center">
+    <progress id="progress-bar" max="{{ params.num_sliders }}" value="0"></progress>
+
     <canvas id="canvas" class="m-2"></canvas>
 
     {{ if DEBUG }}

--- a/sliders/Results.html
+++ b/sliders/Results.html
@@ -5,7 +5,7 @@ Results
 {{ block content }}
 
 <p>
-    You have correctly moved {{ player.solved_sliders }} sliders in {{ player.elapsed_time|to2 }} seconds.
+    You have correctly moved {{ player.num_correct }} sliders in {{ player.elapsed_time|to2 }} seconds.
 </p>
 
 <p>

--- a/sliders/__init__.py
+++ b/sliders/__init__.py
@@ -27,6 +27,7 @@ def creating_session(subsession: Subsession):
     session = subsession.session
     defaults = dict(
         trial_delay=1.0,
+        retry_delay=0.1,
         num_sliders=48,
         num_columns=3,
         attempts_per_slider=10
@@ -195,6 +196,8 @@ def play_game(player: Player, message: dict):
     if message_type == "value":
         if puzzle is None:
             raise RuntimeError("missing puzzle")
+        if puzzle.response_timestamp and now < puzzle.response_timestamp + task_params["retry_delay"]:
+            raise RuntimeError("retrying too fast")
 
         slider = get_slider(puzzle, int(message["slider"]))
 

--- a/sliders/__init__.py
+++ b/sliders/__init__.py
@@ -131,6 +131,7 @@ def get_progress(player: Player):
     """Return current player progress"""
     return dict(
         iteration=player.iteration,
+        solved=player.num_correct
     )
 
 
@@ -210,6 +211,7 @@ def play_game(player: Player, message: dict):
         handle_response(puzzle, slider, value)
         puzzle.response_timestamp = now
         slider.attempts += 1
+        player.num_correct = puzzle.num_correct
 
         p = get_progress(player)
         return {

--- a/sliders/__init__.py
+++ b/sliders/__init__.py
@@ -123,7 +123,7 @@ def encode_puzzle(puzzle: Puzzle):
         image=encode_image(image),
         size=layout['size'],
         grid=layout['grid'],
-        values=[s.value for s in sliders]
+        sliders={s.idx: {'value': s.value, 'is_correct': s.is_correct} for s in sliders}
     )
 
 

--- a/sliders/static/sliders.js
+++ b/sliders/static/sliders.js
@@ -195,9 +195,8 @@ class Controller {
         this.model.sliders[i].is_correct = message.is_correct;
         this.view.render();
 
-        if (message.is_completed) { // current puzzle solved
-            // auto advance to next
-            window.setTimeout(() => this.reqNew(), js_vars.params.trial_delay * 1000);
+        if (message.is_completed) {
+            window.setTimeout(() => this.endGame(), js_vars.params.trial_delay * 1000);
         }
     }
 
@@ -273,13 +272,13 @@ class Controller {
     }
 
     cheat(values) {
-        let i = 0, cnt=Object.keys(obj).length;
+        let i = 0, cnt=Object.keys(values).length;
         let timer = window.setInterval(() => {
             this.model.sliders[i].value = values[i];
             this.submitSlider(i);
             i++;
             if (i == cnt) window.clearInterval(timer);
-        }, 100);
+        }, js_vars.params.retry_delay * 1000 + 100);
     }
 }
 

--- a/sliders/static/sliders.js
+++ b/sliders/static/sliders.js
@@ -4,6 +4,7 @@ class Model {
 //        this.progress = {};
         this.values = [];
         this.correct = [];
+        this.attempts = [];
     }
 
     reset() {
@@ -14,6 +15,7 @@ class Model {
     load(values) {
         this.values = values;
         this.correct = values.map(v => false);
+        this.attempts = values.map(v => 0);
     }
 }
 
@@ -109,7 +111,8 @@ class View {
             let x0 = this.grid[i][0] + this.model.values[i], y0 = this.grid[i][1];
             let dx = x - x0, dy = y - y0;
             if (Math.abs(dx) < 10 && Math.abs(dy) < 10) {
-                return i ;
+                if (this.model.attempts[i] < js_vars.params.attempts_per_slider) return i;
+                return null;
             }
         }
         return null;
@@ -212,6 +215,7 @@ class Controller {
     }
 
     submitSlider(i) {
+        this.model.attempts[i] ++;
         liveSend({type: 'value', slider: i, value: this.model.values[i]});
     }
 

--- a/sliders/static/sliders.js
+++ b/sliders/static/sliders.js
@@ -174,8 +174,7 @@ class Controller {
                 break;
 
             case 'solution':
-                this.model.values = message.solution;
-                this.submitValues();
+                this.cheat(message.solution);
                 break;
         }
 
@@ -191,12 +190,12 @@ class Controller {
     }
 
     recvFeedback(message) {
-        Object.assign(this.model.values, message.values);
-        Object.assign(this.model.correct, message.is_correct);
-
+        let i = message.slider;
+        this.model.values[i] = message.value;
+        this.model.correct[i] = message.is_correct;
         this.view.render();
 
-        if (message.is_complete) { // current puzzle solved
+        if (message.is_completed) { // current puzzle solved
             // auto advance to next
             window.setTimeout(() => this.reqNew(), js_vars.params.trial_delay * 1000);
         }
@@ -212,14 +211,8 @@ class Controller {
         this.reqNew();
     }
 
-    submitValues(i) {
-        let values = {};
-        if (i === undefined) { // all sliders
-            Object.assign(values, this.model.values);
-        } else { // one slider
-            values[i] = this.model.values[i];
-        }
-        liveSend({type: 'values', values: values});
+    submitSlider(i) {
+        liveSend({type: 'value', slider: i, value: this.model.values[i]});
     }
 
     reqNew() {
@@ -264,11 +257,22 @@ class Controller {
         let i = this.picked_slider;
         this.view.drawSlider(i, {});
         this.picked_slider = null;
-        this.submitValues(i);
+        this.submitSlider(i);
     }
 
     endGame() {
         document.getElementById("form").submit();
+    }
+
+    cheat(values) {
+        let i = 0;
+        let timer = window.setInterval(() => {
+            this.model.values[i] = values[i];
+            this.submitSlider(i);
+
+            i++;
+            if (i >= this.model.values.length) window.clearInterval(timer);
+        }, 100);
     }
 }
 

--- a/sliders/static/sliders.js
+++ b/sliders/static/sliders.js
@@ -1,12 +1,12 @@
 class Model {
     /** hold all current game state */
     constructor() {
-//        this.progress = {};
+        this.progress = {};
         this.sliders = {};
     }
 
     reset() {
-//        this.progress = {};
+        this.progress = {};
         this.sliders = {};
     }
 
@@ -22,7 +22,7 @@ class View {
     constructor(model, size) {
         this.model = model;
         this.slider_size = size;
-//        this.$progress = document.getElementById("progress-bar");
+        this.$progress = document.getElementById("progress-bar");
         this.$canvas = document.getElementById("canvas");
         this.size = [];
         this.grid = [];
@@ -124,13 +124,9 @@ class View {
         return Math.abs(dx) < this.slider_size[0]/2 ? dx : null;
     }
 
-//    renderProgress() {
-//        if (this.model.progress.total !== null) {
-//            this.$progress.value = this.model.progress.iteration;
-//        } else {
-//            this.$progress.value = 0;
-//        }
-//    }
+    renderProgress() {
+        this.$progress.value = this.model.progress.solved;
+    }
 }
 
 class Controller {
@@ -182,9 +178,9 @@ class Controller {
                 break;
         }
 
-//        if ('progress' in message) { // can be added to message of any type
-//            this.recvProgress(message.progress);
-//        }
+        if ('progress' in message) { // can be added to message of any type
+            this.recvProgress(message.progress);
+        }
     }
 
     recvPuzzle(data) {
@@ -205,10 +201,10 @@ class Controller {
         }
     }
 
-//    recvProgress(data) {
-//        this.model.progress = data;
-//        this.view.renderProgress();
-//    }
+    recvProgress(data) {
+        this.model.progress = data;
+        this.view.renderProgress();
+    }
 
     startGame() {
         this.starting = false;

--- a/sliders/static/sliders.js
+++ b/sliders/static/sliders.js
@@ -26,7 +26,7 @@ class View {
 //        this.$progress = document.getElementById("progress-bar");
         this.$canvas = document.getElementById("canvas");
         this.size = [];
-        this.sliders = [];
+        this.grid = [];
         this.img = new Image();
         this.canvas = this.$canvas.getContext('2d');
         this.picked_slider = null;
@@ -35,16 +35,16 @@ class View {
     reset() {
         this.img.src = "";
         this.size = [];
-        this.sliders = [];
+        this.grid = [];
     }
 
     clear() {
         this.canvas.clearRect(0, 0, this.$canvas.wodth, this.$canvas.height);
     }
 
-    load(size, sliders, image) {
+    load(size, image, grid) {
         this.size = size;
-        this.sliders = sliders;
+        this.grid = grid;
         this.img.src = image;
         this.img.width = size[0];
         this.img.height = size[1];
@@ -58,7 +58,7 @@ class View {
             return;
         }
         this.canvas.drawImage(this.img, 0, 0);
-        this.sliders.forEach((coord, i) => {
+        this.grid.forEach((coord, i) => {
             let x = coord[0] + this.model.values[i],
                 y = coord[1];
             this.drawHandle(x, y, {correct: this.model.correct[i]});
@@ -66,7 +66,7 @@ class View {
     }
 
     drawSlider(i, state) {
-        let x0 = this.sliders[i][0], y0 = this.sliders[i][1];
+        let x0 = this.grid[i][0], y0 = this.grid[i][1];
         let w = this.slider_size[0] + 40, h = this.slider_size[1];  // +40 margin
         let sx = x0 - w/2, sy = y0 - h/2;
         // copy slider cell from vackground image
@@ -105,8 +105,8 @@ class View {
     }
 
     pickHandle(x, y) {
-        for(let i=0; i < this.sliders.length; i++) {
-            let x0 = this.sliders[i][0] + this.model.values[i], y0 = this.sliders[i][1];
+        for(let i=0; i < this.grid.length; i++) {
+            let x0 = this.grid[i][0] + this.model.values[i], y0 = this.grid[i][1];
             let dx = x - x0, dy = y - y0;
             if (Math.abs(dx) < 10 && Math.abs(dy) < 10) {
                 return i ;
@@ -117,7 +117,7 @@ class View {
 
     mapHandle(i, x, y) {
         // return a value corresponding to coords
-        let dx = x - this.sliders[i][0];
+        let dx = x - this.grid[i][0];
         return Math.abs(dx) < this.slider_size[0]/2 ? dx : null;
     }
 
@@ -185,7 +185,7 @@ class Controller {
 
     recvPuzzle(data) {
         this.model.load(data.values);
-        this.view.load(data.size, data.sliders, data.image);
+        this.view.load(data.size, data.image, data.grid);
         this.view.render();
     }
 

--- a/sliders/static/sliders.js
+++ b/sliders/static/sliders.js
@@ -142,6 +142,7 @@ class Controller {
         this.starting = true;
         this.ts_question = 0;
         this.ts_answer = 0;
+        this.input_disabled = false;
 
         window.liveRecv = (message) => this.recvMessage(message);
 
@@ -228,6 +229,8 @@ class Controller {
     }
 
     pickHandle(event) {
+        if (this.input_disabled) return;
+
         let i = this.view.pickHandle(event.offsetX, event.offsetY);
         this.picked_slider = i;
         if (i !== null) {
@@ -262,6 +265,9 @@ class Controller {
         this.view.drawSlider(i, {});
         this.picked_slider = null;
         this.submitSlider(i);
+
+        this.input_disabled = true;
+        window.setTimeout(() => {this.input_disabled=false}, js_vars.params.retry_delay * 1000);
     }
 
     endGame() {

--- a/sliders/tests.py
+++ b/sliders/tests.py
@@ -1,0 +1,291 @@
+import time
+import random
+import json
+from contextlib import contextmanager
+
+from otree.api import *
+from otree import settings
+
+from . import Player, Puzzle, Game
+from .task_sliders import snap_value, SLIDER_SNAP
+
+
+class PlayerBot(Bot):
+    cases = [
+        "normal",
+        "normal_timeout",
+        "dropout_timeout",
+        "snapping",
+        "reloading",
+        "submitting_null",
+        "submitting_empty",
+        "submitting_none",
+        "submitting_blank",
+        "submitting_premature",
+        # "submitting_toofast",
+        # "submitting_toomany",
+        "skipping",
+        "cheat_debug",
+        "cheat_nodebug",
+    ]
+
+    def play_round(self):
+        if self.case == 'iter_limit' and not self.session.task_params['max_iterations']:
+            print(f"Skipping case {self.case} under no max_iterations")
+            return
+
+        make_timeout = 'timeout' in self.case
+        yield Submission(Game, check_html=False, timeout_happened=make_timeout)
+
+
+# utils
+
+# `m` stands for method
+# `p` for player
+# `z` for puzzle
+# `r` for response
+
+
+def get_last_puzzle(p) -> Puzzle:
+    puzzles = Puzzle.filter(player=p, iteration=p.iteration)
+    puzzle = puzzles[-1] if len(puzzles) else None
+    return puzzle
+
+
+def get_solution(z):
+    return json.loads(z.solution)
+
+
+def get_progress(p):
+    return {
+        "total": len(Puzzle.filter(player=p)),
+    }
+
+
+def send(m, p, t, **values):
+    data = {'type': t}
+    data.update(values)
+    return m(p.id_in_group, data)[p.id_in_group]
+
+
+@contextmanager
+def expect_failure(*exceptions):
+    try:
+        yield
+    except exceptions:
+        return
+    except Exception as e:
+        raise AssertionError(
+            f"A piece of code was expected to fail with {exceptions} but it failed with {e.__class__}"
+        )
+    raise AssertionError(
+        f"A piece of code was expected to fail with {exceptions} but it didn't"
+    )
+
+
+def expect_progress(p, **values):
+    progress = get_progress(p)
+    expect(progress, values)
+
+
+def expect_puzzle(z, **values):
+    expect(z, '!=', None)
+    for k, v in values.items():
+        expect(getattr(z, k), v)
+
+
+def expect_slider(z, i, value):
+    values = json.loads(z.values)
+    expect(values[i], value)
+
+
+def expect_response(r, t, **values):
+    expect(r['type'], t)
+    for k, v in values.items():
+        expect(k, 'in', r)
+        expect(r[k], v)
+
+
+def expect_response_progress(r, **values):
+    expect('progress', 'in', r)
+    expect(r['progress'], values)
+
+
+# test case dispatching
+
+
+def call_live_method(method, group, case, **kwargs):  # noqa
+    print(f"Testing case '{case}'")
+
+    try:
+        test = globals()[f"live_test_{case}"]
+    except KeyError:
+        raise NotImplementedError("Test case not implemented", case)
+
+    test(method, group.get_players()[0], group.session.task_params)
+
+
+# test cases
+
+
+def live_test_normal(method, player, conf):
+    num_sliders = conf['num_sliders']
+
+    send(method, player, 'load')
+    send(method, player, 'new')
+
+    puzzle = get_last_puzzle(player)
+    solution = get_solution(puzzle)
+
+    for i in range(num_sliders):
+        last = (i == num_sliders-1)
+
+        # 1st attempt - incorrect
+        value = solution[i] + SLIDER_SNAP * 2
+        resp = send(method, player, 'value', slider=i, value=value)
+        expect_puzzle(puzzle, iteration=1, correct=i, solved=False)
+        expect_slider(puzzle, i, value)
+        expect_response(resp, 'feedback', slider=i, value=value, is_correct=False, is_completed=False)
+
+        # 2nd attempt - correct
+        value = solution[i]
+        resp = send(method, player, 'value', slider=i, value=value)
+        expect_puzzle(puzzle, iteration=1, correct=i+1, solved=last)
+        expect_slider(puzzle, i, value)
+        expect_response(resp, 'feedback', slider=i, value=value, is_correct=True, is_completed=last)
+
+    expect(puzzle.solved, True)
+
+
+def live_test_normal_timeout(method, player, conf):
+    send(method, player, 'load')
+    send(method, player, 'new')
+    send(method, player, 'value', slider=0, value=100)
+
+
+def live_test_dropout_timeout(method, player, conf):
+    send(method, player, 'load')
+    send(method, player, 'new')
+
+
+def live_test_snapping(method, player, conf):
+    send(method, player, 'load')
+    send(method, player, 'new')
+
+    puzzle = get_last_puzzle(player)
+    solution = get_solution(puzzle)
+
+    value = solution[0] + 100
+    snapped = snap_value(value, solution[0])
+    send(method, player, 'value', slider=0, value=value)
+    expect_slider(puzzle, 0, snapped)
+
+    value = solution[1] + 1
+    snapped = solution[1]
+    send(method, player, 'value', slider=1, value=value)
+    expect_slider(puzzle, 1, snapped)
+
+
+def live_test_reloading(method, player, conf):
+    # start of the game
+    resp = send(method, player, 'load')
+
+    expect(get_last_puzzle(player), None)
+    expect_response(resp, 'status')
+    expect_response_progress(resp, iteration=0)
+
+    resp = send(method, player, 'new')
+    puzzle = get_last_puzzle(player)
+    expect_puzzle(puzzle, iteration=1, correct=0)
+    expect_response(resp, 'puzzle')
+    expect_response_progress(resp, iteration=1)
+
+    # 1 answer
+    solution = get_solution(puzzle)
+    send(method, player, 'value', slider=0, value=solution[0])
+    expect_puzzle(puzzle, iteration=1, correct=1)
+    expect_slider(puzzle, 0, solution[0])
+
+    # midgame reload
+    resp = send(method, player, 'load')
+    expect_response(resp, 'status')
+    expect_response_progress(resp, iteration=1)
+
+    puzzle = get_last_puzzle(player)
+    expect_puzzle(puzzle, iteration=1, correct=1)
+    expect_slider(puzzle, 0, solution[0])
+
+
+def live_test_submitting_null(method, player, conf):
+    send(method, player, 'load')
+    send(method, player, 'new')
+
+    with expect_failure(TypeError):
+        method(player.id_in_group, None)
+
+    expect_puzzle(get_last_puzzle(player), iteration=1, correct=0, solved=False)
+
+
+def live_test_submitting_empty(method, player, conf):
+    send(method, player, 'load')
+    send(method, player, 'new')
+
+    with expect_failure(KeyError):
+        method(player.id_in_group, {})
+
+    expect_puzzle(get_last_puzzle(player), iteration=1, correct=0, solved=False)
+
+
+def live_test_submitting_none(method, player, conf):
+    send(method, player, 'load')
+    send(method, player, 'new')
+
+    with expect_failure(KeyError):
+        send(method, player, 'value')
+
+    expect_puzzle(get_last_puzzle(player), iteration=1, correct=0, solved=False)
+
+
+def live_test_submitting_blank(method, player, conf):
+    send(method, player, 'load')
+    send(method, player, 'new')
+
+    with expect_failure(ValueError):
+        send(method, player, 'value', slider=0, value="")
+
+    expect_puzzle(get_last_puzzle(player), iteration=1, correct=0, solved=False)
+
+
+def live_test_submitting_premature(method, player, conf):
+    send(method, player, 'load')
+
+    with expect_failure(RuntimeError):
+        send(method, player, 'value', slider=0, value=100)
+
+
+def live_test_skipping(method, player, conf):
+    send(method, player, 'load')
+    send(method, player, 'new')
+
+    with expect_failure(RuntimeError):
+        send(method, player, 'new')
+
+    expect_puzzle(get_last_puzzle(player), iteration=1, correct=0, solved=False)
+
+
+def live_test_cheat_debug(method, player, conf):
+    settings.DEBUG = True
+    send(method, player, 'load')
+    send(method, player, 'new')
+
+    resp = send(method, player, 'cheat')
+    expect_response(resp, 'solution')
+
+
+def live_test_cheat_nodebug(method, player, conf):
+    settings.DEBUG = False
+    send(method, player, 'load')
+    send(method, player, 'new')
+
+    with expect_failure(RuntimeError):
+        send(method, player, 'cheat')


### PR DESCRIPTION
Major refactor of the sliders app.

- separated database models into `Puzzle` (for layout and stats) and `Slider` (target and state of each slider). That simplifies code a lot.
- only single-slider submit, Close #14
- limit number of attempts per slider, Close #17
- limit rate of submits, Close #16
- preserving sliders status on reload, Close #18
- added progress bar
- added tests
